### PR TITLE
Fix peerDependencies warning on ios, add string type support on ios

### DIFF
--- a/ios/Osc.swift
+++ b/ios/Osc.swift
@@ -47,6 +47,8 @@ import SwiftOSC
                     message.add(someDouble)
                 case let someBool as Bool:
                     message.add(someBool)
+                case let someString as String:
+                    message.add(someString)  // 将字符串加入消息
                 default:
                     print("data not supported")
             }

--- a/ios/Osc.swift
+++ b/ios/Osc.swift
@@ -48,7 +48,7 @@ import SwiftOSC
                 case let someBool as Bool:
                     message.add(someBool)
                 case let someString as String:
-                    message.add(someString)  // 将字符串加入消息
+                    message.add(someString)
                 default:
                     print("data not supported")
             }

--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
   "licenseFilename": "LICENSE",
   "readmeFilename": "README.md",
   "peerDependencies": {
-    "react": "^16.8.1",
-    "react-native": ">=0.60.0-rc.0 <1.0.x"
+    "react": "*",
+    "react-native": "*"
   },
   "devDependencies": {
     "react": "^16.9.0",


### PR DESCRIPTION
Fix peerDependencies warning on ios, add string type support on ios